### PR TITLE
One more UTC bugfix for the road

### DIFF
--- a/gmetad-python/plugins/mongodb.py
+++ b/gmetad-python/plugins/mongodb.py
@@ -75,11 +75,7 @@ class MongodbPlugin(GmetadPlugin) :
         self.msci = self.api.msci
 
         self.obj_cache = {}
-        tzoffset = datetime.utcfromtimestamp(-1).hour - datetime.fromtimestamp(0).hour + 1
-        if tzoffset == 24 :
-            tzoffset = 0
-        _now = int(time()) + (3600 * tzoffset)
-        self.last_refresh = str(_now)
+        self.last_refresh = str(time())
 
         self.expid = self.api.cldshow(self.cloud_name, "time")["experiment_id"]
         self.username = self.api.username
@@ -108,11 +104,7 @@ class MongodbPlugin(GmetadPlugin) :
             if verbose :
                 logging.debug("Should refresh returned true!")
             plugin.obj_cache = {}
-            tzoffset = datetime.utcfromtimestamp(-1).hour - datetime.fromtimestamp(0).hour + 1
-            if tzoffset == 24 :
-                tzoffset = 0
-            _now = int(time()) + (3600 * tzoffset)
-            plugin.last_refresh = str(_now)
+            plugin.last_refresh = str(time())
         if ip in plugin.obj_cache :
             (exists, unused_obj) = plugin.obj_cache[ip]
             if verbose : 
@@ -228,13 +220,14 @@ class MongodbPlugin(GmetadPlugin) :
                 empty = False
 
             if not empty :
+                # epochs are already timezone-less. It's only the human timestamps that need to be corrected.
                 tzoffset = datetime.utcfromtimestamp(-1).hour - datetime.fromtimestamp(0).hour + 1
                 if tzoffset == 24 :
                     tzoffset = 0
-                _now = int(time()) + (3600 * tzoffset)
+                _data["time"] = time()
+                _now = int(_data["time"]) + (3600 * tzoffset)
                 _data["time_h"] = makeTimestamp(_now)
-                _data["time"] = _now 
-                _data["latest_update"] = _now
+                _data["latest_update"] = _data["time"]
 
                 try :
                     if obj_type == "VM" :


### PR DESCRIPTION
So, most of the UTC repairs we performed last year were correct, except for this one.

Unix "epochs" by themselves are timezone-less. It's when they are "interpreted" as human-readable
timestamps that they are parsed by python incorrectly.

When these epochs (from time()) are directly compared to each other, they are timezone-less,
and do not need to be offset.

But, when they are "fed" to python to be converted as human-readable, those rare cases are
when the timezones get lost.

We've already handled correctly in the past when human timestamps are compared to human
timestamps --- that all works fine --- no repair needed there.